### PR TITLE
Add bison/flex support to CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,17 @@ project(pas)
 
 set(CMAKE_CXX_STANDARD 11)
 
+find_package(BISON REQUIRED)
+find_package(FLEX REQUIRED)
+
+bison_target(p16Parser src/p16.ypp ${CMAKE_CURRENT_BINARY_DIR}/p16.tab.cpp)
+flex_target(p16Scanner src/p16.l ${CMAKE_CURRENT_BINARY_DIR}/p16.lex.cpp)
+
+ADD_FLEX_BISON_DEPENDENCY(p16Scanner p16Parser)
+
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
+
 add_executable(pas
         src/cpp_printf.cpp
         src/cpp_printf.h
@@ -15,8 +26,8 @@ add_executable(pas
         src/p16.h
         src/p16.l
         src/p16.ypp
-        src/p16.tab.cpp
-        src/p16.lex.cpp
+        ${BISON_p16Parser_OUTPUTS}
+        ${FLEX_p16Scanner_OUTPUTS}
         src/instruction.cpp
         src/instruction.h
         src/listing_generator.h


### PR DESCRIPTION
Fixes error when running cmake on Debian GNU/Linux 10.3:

    ~/src/p16_assembler$ mkdir build ; cd build ; cmake ..
    /home/joao/src/p16_assembler/build
    -- The C compiler identification is GNU 8.3.0
    -- The CXX compiler identification is GNU 8.3.0
    -- Check for working C compiler: /usr/bin/cc
    -- Check for working C compiler: /usr/bin/cc -- works
    -- Detecting C compiler ABI info
    -- Detecting C compiler ABI info - done
    -- Detecting C compile features
    -- Detecting C compile features - done
    -- Check for working CXX compiler: /usr/bin/c++
    -- Check for working CXX compiler: /usr/bin/c++ -- works
    -- Detecting CXX compiler ABI info
    -- Detecting CXX compiler ABI info - done
    -- Detecting CXX compile features
    -- Detecting CXX compile features - done
    -- Configuring done
    CMake Error at CMakeLists.txt:6 (add_executable):
      Cannot find source file:
    
        src/p16.tab.cpp
    
      Tried extensions .c .C .c++ .cc .cpp .cxx .cu .m .M .mm .h .hh .h++ .hm
      .hpp .hxx .in .txx
    
    
    CMake Error at CMakeLists.txt:6 (add_executable):
      No SOURCES given to target: pas
    
    
    -- Build files have been written to: /home/joao/src/p16_assembler/build