### PR TITLE
Corrigir utilização implícita de stdint

### DIFF
--- a/src/expression_base.h
+++ b/src/expression_base.h
@@ -17,6 +17,8 @@ limitations under the License.
 #ifndef EXPRESSION_BASE_H
 #define EXPRESSION_BASE_H
 
+#include <stdint.h>
+
 #include "value_type.h"
 #include "location.h"
 #include "visitor.h"


### PR DESCRIPTION
Alguns compiladores não permitem a utilização de tipos `stdint` por defeito.
A inclusão de `stdint.h` resolve este problema.
